### PR TITLE
Add all steps to one action

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ This repository is holding the Github Action that enables the Jit platform to ru
 
 ```yaml
 inputs:
+  pull_key:
+    description: 'key for pulling the action repo'
+    required: true
+  docker_user:
+    description: 'user for docker registry'
+    required: true
+  docker_password:
+    registr: 'password for docker registry'
+    required: true
   target_dir:
     description: 'Directory to scan'
     required: true

--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ inputs:
   docker_password:
     registr: 'password for docker registry'
     required: true
-  target_dir:
-    description: 'Directory to scan'
-    required: true
   security_control:
     description: "Docker image tag path of security control to execute"
     required: true

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,15 @@
 name: 'Jit security-controls action'
 description: 'Runs a Jit security-control on a target dir'
 inputs:
+  pull_key:
+    description: 'key for pulling the action repo'
+    required: true
+  docker_user:
+    description: 'user for docker registry'
+    required: true
+  docker_password:
+    registr: 'password for docker registry'
+    required: true
   target_dir:
     description: 'Directory to scan'
     required: true
@@ -14,6 +23,30 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: |
+    - name: Checkout .jit
+      uses: actions/checkout@v2
+      with:
+        repository: ${{ github.repository }}
+        token: ${{ github.event.client_payload.payload.github_token }}
+        ref: main
+        path: ".jit/"
+    - name: Checkout original repository
+      uses: actions/checkout@v2
+      with:
+        repository: ${{ github.event.client_payload.payload.full_repo_path }}
+        ref: ${{ github.event.client_payload.payload.commits.head_sha }}
+        fetch-depth: 0
+        token: ${{ github.event.client_payload.payload.github_token }}
+        path: "code/"
+    - name: Check out jit-github-actions
+      uses: actions/checkout@v2
+      with:
+        repository: jitsecurity-controls/jit-github-action
+        ref: main
+        token: ${{ inputs.pull_key }}
+        path: ./.github/actions/jit-github-action
+    - name: Run The Action
+      run: |
+        docker login ghcr.io --username ${{ inputs.docker_user }} --password ${{ inputs.docker_password }}
         docker run --rm -e CONFIG_FILE_PATH=/.jit/jit.yml -e GITHUB_EVENT='${{ toJSON(github) }}' -e SOURCE_CODE_FOLDER=/code -v $(pwd)/.jit:/.jit -v $(pwd)/${{ inputs.target_dir }}:/code ${{ inputs.security_control }} -- ${{ inputs.security_control_args }} > artifact.json
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -10,9 +10,6 @@ inputs:
   docker_password:
     registr: 'password for docker registry'
     required: true
-  target_dir:
-    description: 'Directory to scan'
-    required: true
   security_control:
     description: "Docker image tag path of security control to execute"
     required: true
@@ -48,5 +45,5 @@ runs:
     - name: Run The Action
       run: |
         docker login ghcr.io --username ${{ inputs.docker_user }} --password ${{ inputs.docker_password }}
-        docker run --rm -e CONFIG_FILE_PATH=/.jit/jit.yml -e GITHUB_EVENT='${{ toJSON(github) }}' -e SOURCE_CODE_FOLDER=/code -v $(pwd)/.jit:/.jit -v $(pwd)/${{ inputs.target_dir }}:/code ${{ inputs.security_control }} -- ${{ inputs.security_control_args }} > artifact.json
+        docker run --rm -e CONFIG_FILE_PATH=/.jit/jit.yml -e GITHUB_EVENT='${{ toJSON(github) }}' -e SOURCE_CODE_FOLDER=/code -v $(pwd)/.jit:/.jit -v $(pwd)/code:/code ${{ inputs.security_control }} -- ${{ inputs.security_control_args }} > artifact.json
       shell: bash


### PR DESCRIPTION
all steps of the Jit security flow in one action

this is how we use this action:

```yaml
  python-code-scanning:
    runs-on: ubuntu-latest
    steps:
    - name: github action
      id: test
      uses: jitsecurity-controls/jit-github-action
      with:
        pull_key: ${{ secrets.PULL_KEY }}
        docker_user: ${{ secrets.GHCR_REGISTRY_USER }}
        docker_password: ${{ secrets.GHCR_REGISTRY_TOKEN }}
        security_control: ghcr.io/jitsecurity-controls/control-bandit-slim:latest        
        security_control_args: -r /code -f json -q -ll -iii

```