### PR TITLE
Add param for output file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
   security_control_args:
     description: "argument to pass to the security control"
     required: false
+  security_control_output_file:
+    description: "path to the security control output"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -49,5 +53,5 @@ runs:
       run: |
         docker login ghcr.io --username ${{ inputs.docker_user }} --password ${{ inputs.docker_password }}
         docker pull ${{ inputs.security_control }}
-        docker run --rm -e CONFIG_FILE_PATH=/.jit/jit.yml -e GITHUB_EVENT='${{ toJSON(github) }}' -e SOURCE_CODE_FOLDER=/code -v $(pwd)/.jit:/.jit -v $(pwd)/code:/code ${{ inputs.security_control }} -- ${{ inputs.security_control_args }} > artifact.json
+        docker run --rm -e CONFIG_FILE_PATH=/.jit/jit.yml -e GITHUB_EVENT='${{ toJSON(github) }}' -e SOURCE_CODE_FOLDER=/code -e SECURITY_CONTROL_OUTPUT_FILE=${{ inputs.security_control_output_file }} -v $(pwd)/.jit:/.jit -v $(pwd)/code:/code ${{ inputs.security_control }} -- ${{ inputs.security_control_args }} > artifact.json
       shell: bash


### PR DESCRIPTION
Support output file for controls using an output file instead of stdout (i.e. `dependency-check`)