### PR TITLE
remove the docker cache action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,8 +42,6 @@ runs:
         ref: main
         token: ${{ inputs.pull_key }}
         path: ./.github/actions/jit-github-action
-    - name: Cache container image
-      uses: satackey/action-docker-layer-caching@v0.0.11
     - name: Run The Action
       if: always()
       run: |


### PR DESCRIPTION
This cache adds 1 minute to run time and doesn't seem to use the cache it created previously.