### PR TITLE
**WIP** [SC-1257] Update action to use a default hard-coded token to retrieve controls

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,7 @@ inputs:
   pull_key:
     description: 'key for pulling the action repo'
     required: true
+    default: ${{ secrets.GHCR_REGISTRY_TOKEN }}
   docker_user:
     description: 'user for docker registry'
     required: true
@@ -69,7 +70,6 @@ runs:
       with:
         repository: jitsecurity-controls/jit-github-action
         ref: main
-        token: ${{ inputs.pull_key }}
         path: ./.github/actions/jit-github-action
     - name: Run The Action
       if: always()

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
         docker login ghcr.io --username $REGISTRY_USER --password $REGISTRY_TOKEN
         docker pull ${{ inputs.security_control }}
         docker run --rm -e CONFIG_FILE_PATH=/.jit/jit.yml -e GITHUB_EVENT='${{ toJSON(github) }}' -e SOURCE_CODE_FOLDER=/code -e SECURITY_CONTROL_OUTPUT_FILE=${{ inputs.security_control_output_file }} -v $(pwd)/.jit:/.jit -v $(pwd)/code:/code ${{ inputs.security_control }} -- ${{ inputs.security_control_args }} > artifact.json
-      with:
+      env:
         REGISTRY_USER: ${{ secrets.GHCR_REGISTRY_USER }}
         REGISTRY_TOKEN: ${{ secrets.GHCR_REGISTRY_TOKEN }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,11 @@ inputs:
   docker_user:
     description: 'user for docker registry'
     required: true
+    default: "jit-bot"
   docker_password:
     description: 'password for docker registry'
     required: true
+    default: "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"
   security_control:
     description: "Docker image tag path of security control to execute"
     required: true

--- a/action.yml
+++ b/action.yml
@@ -7,11 +7,11 @@ inputs:
   docker_user:
     description: 'user for docker registry'
     required: true
-    default: "jit-bot"
+    default: ${{ secrets.GHCR_REGISTRY_USER }}
   docker_password:
     description: 'password for docker registry'
     required: true
-    default: "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"
+    default: ${{ secrets.GHCR_REGISTRY_TOKEN }}
   security_control:
     description: "Docker image tag path of security control to execute"
     required: true

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,10 @@ runs:
     - name: Run The Action
       if: always()
       run: |
-        docker login ghcr.io --username ${{ secrets.GHCR_REGISTRY_USER }} --password ${{ secrets.GHCR_REGISTRY_TOKEN }}
+        docker login ghcr.io --username $REGISTRY_USER --password $REGISTRY_TOKEN
         docker pull ${{ inputs.security_control }}
         docker run --rm -e CONFIG_FILE_PATH=/.jit/jit.yml -e GITHUB_EVENT='${{ toJSON(github) }}' -e SOURCE_CODE_FOLDER=/code -e SECURITY_CONTROL_OUTPUT_FILE=${{ inputs.security_control_output_file }} -v $(pwd)/.jit:/.jit -v $(pwd)/code:/code ${{ inputs.security_control }} -- ${{ inputs.security_control_args }} > artifact.json
+      with:
+        REGISTRY_USER: ${{ secrets.GHCR_REGISTRY_USER }}
+        REGISTRY_TOKEN: ${{ secrets.GHCR_REGISTRY_TOKEN }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,18 +1,6 @@
 name: 'Jit security-controls action'
 description: 'Runs a Jit security-control on a target dir'
 inputs:
-  pull_key:
-    description: 'key for pulling the action repo'
-    required: true
-    default: ${{ secrets.GHCR_REGISTRY_TOKEN }}
-  docker_user:
-    description: 'user for docker registry'
-    required: true
-    default: ${{ secrets.GHCR_REGISTRY_USER }}
-  docker_password:
-    description: 'password for docker registry'
-    required: true
-    default: ${{ secrets.GHCR_REGISTRY_TOKEN }}
   security_control:
     description: "Docker image tag path of security control to execute"
     required: true
@@ -74,7 +62,7 @@ runs:
     - name: Run The Action
       if: always()
       run: |
-        docker login ghcr.io --username ${{ inputs.docker_user }} --password ${{ inputs.docker_password }}
+        docker login ghcr.io --username ${{ secrets.GHCR_REGISTRY_USER }} --password ${{ secrets.GHCR_REGISTRY_TOKEN }}
         docker pull ${{ inputs.security_control }}
         docker run --rm -e CONFIG_FILE_PATH=/.jit/jit.yml -e GITHUB_EVENT='${{ toJSON(github) }}' -e SOURCE_CODE_FOLDER=/code -e SECURITY_CONTROL_OUTPUT_FILE=${{ inputs.security_control_output_file }} -v $(pwd)/.jit:/.jit -v $(pwd)/code:/code ${{ inputs.security_control }} -- ${{ inputs.security_control_args }} > artifact.json
       shell: bash


### PR DESCRIPTION
Update action to use a default hard-coded token to retrieve controls (generated by the `jit-bot` user)

https://app.shortcut.com/jit/story/1257/gh-permissions-update-hard-coded-token

Deployment note: we need to either override the current tag or update the `.jit` to use the new tag.