### PR TITLE
SC-1339 - Remove deprecated dispatch_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ inputs:
     required: false
     default: ""
   dispatch_type:
-    description: "'workflow' or 'repository' (repository dispatch is deprecated and will be removed)"
+    description: "'workflow' or 'repository' (dispatch_type is deprecated and will be removed once all clients <controls> stop sending it)"
     required: false
-    default: "repository"
+    default: "workflow"
 ```

--- a/README.md
+++ b/README.md
@@ -25,4 +25,8 @@ inputs:
     description: "path to the security control output"
     required: false
     default: ""
+  dispatch_type:
+    description: "'workflow' or 'repository' (dispatch_type is deprecated and will be removed once all clients <controls> stop sending it)"
+    required: false
+    default: "workflow"
 ```

--- a/README.md
+++ b/README.md
@@ -25,8 +25,4 @@ inputs:
     description: "path to the security control output"
     required: false
     default: ""
-  dispatch_type:
-    description: "'workflow' or 'repository' (dispatch_type is deprecated and will be removed once all clients <controls> stop sending it)"
-    required: false
-    default: "workflow"
 ```

--- a/action.yml
+++ b/action.yml
@@ -18,15 +18,14 @@ inputs:
     required: false
     default: ""
   dispatch_type:
-    description: "'workflow' or 'repository' (repository dispatch is deprecated and will be removed)"
+    description: "'workflow' or 'repository' (dispatch_type is deprecated and will be removed)"
     required: false
-    default: "repository"
+    default: "workflow"
 
 runs:
   using: "composite"
   steps:
     - name: Checkout .jit
-      if: ${{ inputs.dispatch_type == 'workflow' }}
       uses: actions/checkout@v2   
       with:
         repository: ${{ github.repository }}
@@ -34,30 +33,12 @@ runs:
         ref: main
         path: ".jit/"
     - name: Checkout original repository
-      if: ${{ inputs.dispatch_type == 'workflow' }}
       uses: actions/checkout@v2
       with:
         repository: ${{ fromJSON(github.event.inputs.client_payload).payload.full_repo_path }}
         ref: ${{ fromJSON(github.event.inputs.client_payload).payload.commits.head_sha }}
         fetch-depth: 0
         token: ${{ fromJSON(github.event.inputs.client_payload).payload.github_token }}
-        path: "code/"
-    - name: Checkout .jit (using deprecated repository)
-      if: ${{ inputs.dispatch_type == 'repository' }}
-      uses: actions/checkout@v2
-      with:
-        repository: ${{ github.repository }}
-        token: ${{ github.event.client_payload.payload.github_token }}
-        ref: main
-        path: ".jit/"
-    - name: Checkout original repository (using deprecated repository)
-      if: ${{ inputs.dispatch_type == 'repository' }}
-      uses: actions/checkout@v2
-      with:
-        repository: ${{ github.event.client_payload.payload.full_repo_path }}
-        ref: ${{ github.event.client_payload.payload.commits.head_sha }}
-        fetch-depth: 0
-        token: ${{ github.event.client_payload.payload.github_token }}
         path: "code/"
     - name: Check out jit-github-actions
       uses: actions/checkout@v2

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: "path to the security control output"
     required: false
     default: ""
+  dispatch_type:
+    description: "'workflow' or 'repository' (dispatch_type is deprecated and will be removed)"
+    required: false
+    default: "workflow"
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -17,10 +17,6 @@ inputs:
     description: "path to the security control output"
     required: false
     default: ""
-  dispatch_type:
-    description: "'workflow' or 'repository' (dispatch_type is deprecated and will be removed)"
-    required: false
-    default: "workflow"
 
 runs:
   using: "composite"

--- a/images/.github/PULL_REQUEST_TEMPLATE.md
+++ b/images/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+## Shortcut ticket:
+
+[SC-###](https://app.shortcut.com/jit/story/###)
+
+## Why did you make this change
+
+<!-- Describe what is the purpose of this change -->
+
+## What have you done in this PR
+
+<!-- High-level description of the change -->
+
+## What was left to do
+
+<!-- Describe what is left to do and not included in this PR -->
+
+## Dependencies
+
+<!-- Describe any dependencies that this PR has -->
+
+## Security reviews
+
+<!-- Describe any security reviews that have been done on this PR if relevant -->
+
+-   [ ] I conducted a security review of my work
+-   [ ] I need a security review for this PR
+
+## How Was This Tested?
+
+<!-- Describe the tests that you ran to verify your changes -->
+
+-   [ ] Local
+-   [ ] Dev
+-   [ ] Stage
+
+## Checklist:
+
+<!-- Check the relevant options and remove the ones that aren't relevant -->
+
+-   [ ] My code follows the style guidelines of this project
+-   [ ] I have performed a self-review of my own code
+-   [ ] I have added tests that prove my fix is effective or that my feature works
+-   [ ] I have made corresponding changes to the documentation


### PR DESCRIPTION
## Shortcut ticket:

[SC-1339](https://app.shortcut.com/jit/story/1339)

## Why did you make this change

<!-- Describe what is the purpose of this change -->

In [SC-1258](https://app.shortcut.com/jit/story/1258) we added the option to dispatch workflow 
in favor of the repository dispatch.
 
In the transition phase, we wanted to support both options.
Now that all clients (controls) are using the **_workflow-dispatch_** options, we can remove the **_repository-dispatch_**
option.

We need to do this in 2 stages 
1. remove the usage to the `dispatch_type` in this repo
2. stop sending the `dispatch_type` from all clients (`.jit` files)
3. remove `dispatch_type` from the inputs params

## What have you done in this PR

<!-- High-level description of the change -->
- Remove the `dispatch_type` usage
- Add PR template file

## What was left to do
<!-- Describe what is left to do and not included in this PR -->
- Update all clients to stop sending the `dispatch_type`
- Remove the `dispatch_type` from the input params

## Dependencies

<!-- Describe any dependencies that this PR has -->
None
## Security reviews

<!-- Describe any security reviews that have been done on this PR if relevant -->

-   [X] I conducted a security review of my work
-   [ ] I need a security review for this PR

## How Was This Tested?

<!-- Describe the tests that you ran to verify your changes -->

-   [ ] Local
-   [X] Birds
-   [ ] Dev
-   [ ] Stage

## Checklist:

<!-- Check the relevant options and remove the ones that aren't relevant -->

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have made corresponding changes to the documentation