### PR TITLE
[sc-12558] - rename .jit to be centralized repo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout .jit
+    - name: Checkout centralized repository
       uses: actions/checkout@v2   
       with:
         repository: ${{ github.repository }}


### PR DESCRIPTION
rename .jit to be centralized repository for better naming