### PR TITLE
Remove security control args

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,6 @@ inputs:
   security_control:
     description: "Docker image tag path of security control to execute"
     required: true
-  security_control_args:
-    description: "argument to pass to the security control"
-    required: false
   security_control_output_file:
     description: "path to the security control output"
     required: false
@@ -124,7 +121,7 @@ runs:
         then
           echo SECURITY_CONTROL_OUTPUT_FILE=${{ inputs.security_control_output_file }} >> /tmp/docker_env.txt
         fi
-        docker run --rm --env-file /tmp/docker_env.txt ${{ inputs.container_args }} ${{ fromJSON(github.event.inputs.client_payload).payload.control_env_vars }} -v ${CENTRALIZED_REPO_FILES_LOCATION_PATH}:/.jit ${{ env.mount_original_repo_command }} ${{ steps.set-image.outputs.image }} -- ${{ inputs.security_control_args }}
+        docker run --rm --env-file /tmp/docker_env.txt ${{ inputs.container_args }} ${{ fromJSON(github.event.inputs.client_payload).payload.control_env_vars }} -v ${CENTRALIZED_REPO_FILES_LOCATION_PATH}:/.jit ${{ env.mount_original_repo_command }} ${{ steps.set-image.outputs.image }}
       shell: bash
       env:
         # this field would set the original repo command mount command (would be mounted always in the old flow) and only if checkout = true in the new flow

--- a/action.yml
+++ b/action.yml
@@ -32,10 +32,6 @@ inputs:
   runner_setup:
     description: RunnerSetup dictionary
     default: '{"checkout": true}'
-  context:
-    description: Execution context
-    default: '{}'
-
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -21,10 +21,6 @@ inputs:
     description: "path to the security control output"
     required: false
     default: ""
-  dispatch_type:
-    description: "'workflow' or 'repository' (dispatch_type is deprecated and will be removed)"
-    required: false
-    default: "workflow"
   fail_on_findings:
     description: "fail control when finding is found"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   fail_on_findings:
     description: "fail control when finding is found"
     required: false
-    default: true
+    default: "true"
   runner_setup:
     description: RunnerSetup dictionary
     default: '{"checkout": true}'

--- a/action.yml
+++ b/action.yml
@@ -125,7 +125,14 @@ runs:
         then
           echo SECURITY_CONTROL_OUTPUT_FILE=${{ inputs.security_control_output_file }} >> /tmp/docker_env.txt
         fi
-        docker run --rm ${{ inputs.inline_environment }} --env-file /tmp/docker_env.txt ${{ inputs.container_args }} ${{ fromJSON(github.event.inputs.client_payload).payload.control_env_vars }} -v ${CENTRALIZED_REPO_FILES_LOCATION_PATH}:/.jit ${{ env.mount_original_repo_command }} ${{ steps.set-image.outputs.image }}
+        docker run \
+          --rm \
+          ${{ inputs.inline_environment }} \
+          --env-file /tmp/docker_env.txt \
+          ${{ inputs.container_args }} \
+          -v ${CENTRALIZED_REPO_FILES_LOCATION_PATH}:/.jit \
+          ${{ env.mount_original_repo_command }} \
+          ${{ steps.set-image.outputs.image }}
       shell: bash
       env:
         # this field would set the original repo command mount command (would be mounted always in the old flow) and only if checkout = true in the new flow

--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,6 @@
 name: 'Jit security-controls action'
 description: 'Runs a Jit security-control on a target dir'
 inputs:
-  docker_user:
-    description: 'user for docker registry'
-    required: true
-  docker_password:
-    description: 'password for docker registry'
-    required: true
   container_args:
     description: 'container additional args'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
   runner_setup:
     description: RunnerSetup dictionary
     default: '{"checkout": true}'
+  inline_environment:
+    description: "inline environment variables to be passed to the container"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -121,7 +125,7 @@ runs:
         then
           echo SECURITY_CONTROL_OUTPUT_FILE=${{ inputs.security_control_output_file }} >> /tmp/docker_env.txt
         fi
-        docker run --rm --env-file /tmp/docker_env.txt ${{ inputs.container_args }} ${{ fromJSON(github.event.inputs.client_payload).payload.control_env_vars }} -v ${CENTRALIZED_REPO_FILES_LOCATION_PATH}:/.jit ${{ env.mount_original_repo_command }} ${{ steps.set-image.outputs.image }}
+        docker run --rm ${{ inputs.inline_environment }} --env-file /tmp/docker_env.txt ${{ inputs.container_args }} ${{ fromJSON(github.event.inputs.client_payload).payload.control_env_vars }} -v ${CENTRALIZED_REPO_FILES_LOCATION_PATH}:/.jit ${{ env.mount_original_repo_command }} ${{ steps.set-image.outputs.image }}
       shell: bash
       env:
         # this field would set the original repo command mount command (would be mounted always in the old flow) and only if checkout = true in the new flow


### PR DESCRIPTION
Added a new optional input of `inline_environment` to the action which is being passed to the `docker run` command. In addition, removed deprecated inputs which are not being used anymore.

Ticket: https://app.shortcut.com/jit/story/18335/jit-github-action-plan-service-support-new-flow