### PR TITLE
add pre-register step & don't fail enrichment on empty repo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,13 +32,13 @@ runs:
       continue-on-error: true
       run: |
         echo "Linking job ID to Jit"
-        RUN_ID=${{ fromJSON(github.run_id) }}
-        JIT_EVENT_ID=${{ fromJSON(github.event.inputs.client_payload).context.jit_event.jit_event_id }}
-        EXECUTION_ID=${{ fromJSON(github.event.inputs.client_payload).execution_data.execution_id }}
+        CI_RUN_ID=${{ fromJSON(github.run_id) }}
+        CI_JIT_EVENT_ID=${{ fromJSON(github.event.inputs.client_payload).context.jit_event.jit_event_id }}
+        CI_EXECUTION_ID=${{ fromJSON(github.event.inputs.client_payload).execution_data.execution_id }}
         BODY=$( jq -n \
-                  --arg vendor_job_id "$RUN_ID" \
-                  --arg jit_event_id "$JIT_EVENT_ID" \
-                  --arg execution_id "$EXECUTION_ID" \
+                  --arg vendor_job_id "$CI_RUN_ID" \
+                  --arg jit_event_id "$CI_JIT_EVENT_ID" \
+                  --arg execution_id "$CI_EXECUTION_ID" \
                   '{vendor_job_id: $vendor_job_id, jit_event_id: $jit_event_id, execution_id: $execution_id}' )
         curl \
           -X POST \

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,7 @@ runs:
       shell: bash
       continue-on-error: true
       run: |
+        echo "Linking job ID to Jit"
         RUN_ID=${{ fromJSON(github.run_id) }}
         JIT_EVENT_ID=${{ fromJSON(github.event.inputs.client_payload).context.jit_event.jit_event_id }}
         EXECUTION_ID=${{ fromJSON(github.event.inputs.client_payload).execution_data.execution_id }}
@@ -38,7 +39,7 @@ runs:
                   --arg vendor_job_id "$RUN_ID" \
                   --arg jit_event_id "$JIT_EVENT_ID" \
                   --arg execution_id "$EXECUTION_ID" \
-                  '{vendor_job_id: $run_id, jit_event_id: $jit_event_id, execution_id: $execution_id}' )
+                  '{vendor_job_id: $vendor_job_id, jit_event_id: $jit_event_id, execution_id: $execution_id}' )
         curl \
           -X POST \
           -H "Authorization: Bearer ${{ fromJSON(github.event.inputs.client_payload).operational_data.callback_token }}" \

--- a/action.yml
+++ b/action.yml
@@ -32,13 +32,13 @@ runs:
       continue-on-error: true
       run: |
         RUN_ID=${{ fromJSON(github.run_id) }}
-        JIT_EVENT_ID=${{ fromJSON(github.event.inputs.client_payload).jit_event.jit_event_id }}
+        JIT_EVENT_ID=${{ fromJSON(github.event.inputs.client_payload).context.jit_event.jit_event_id }}
         EXECUTION_ID=${{ fromJSON(github.event.inputs.client_payload).execution_data.execution_id }}
         BODY=$( jq -n \
                   --arg vendor_job_id "$RUN_ID" \
                   --arg jit_event_id "$JIT_EVENT_ID" \
                   --arg execution_id "$EXECUTION_ID" \
-                  '{run_id: $run_id, jit_event_id: $jit_event_id, execution_id: $execution_id}' )
+                  '{vendor_job_id: $run_id, jit_event_id: $jit_event_id, execution_id: $execution_id}' )
         curl \
           -X POST \
           -H "Authorization: Bearer ${{ fromJSON(github.event.inputs.client_payload).operational_data.callback_token }}" \

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,25 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Link job ID to Execution
+      shell: bash
+      continue-on-error: true
+      run: |
+        RUN_ID=${{ fromJSON(github.run_id) }}
+        JIT_EVENT_ID=${{ fromJSON(github.event.inputs.client_payload).jit_event.jit_event_id }}
+        EXECUTION_ID=${{ fromJSON(github.event.inputs.client_payload).execution_data.execution_id }}
+        BODY=$( jq -n \
+                  --arg vendor_job_id "$RUN_ID" \
+                  --arg jit_event_id "$JIT_EVENT_ID" \
+                  --arg execution_id "$EXECUTION_ID" \
+                  '{run_id: $run_id, jit_event_id: $jit_event_id, execution_id: $execution_id}' )
+        curl \
+          -X POST \
+          -H "Authorization: Bearer ${{ fromJSON(github.event.inputs.client_payload).operational_data.callback_token }}" \
+          -H "Content-Type: application/json" \
+          -d "$BODY" \
+          ${{ fromJSON(github.event.inputs.client_payload).operational_data.callback_urls.base_api }}/execution/start
+
     - name: Set centralized_repo_files_location env var
       shell: bash
       env:
@@ -44,6 +63,8 @@ runs:
         path: ".jit/"
 
     - name: Checkout original repository
+      # we don't want enrichment to fail the action on empty repo, it has its own logic to handle it
+      continue-on-error: true
       # this if should pass if there is not runner setup (old flow would checkout always) or when new flow ask to checkout
       if: ${{ ((!(fromJSON(inputs.runner_setup)) || (fromJSON(inputs.runner_setup).checkout == true)))  }}
       uses: actions/checkout@v3


### PR DESCRIPTION
CI submits start request:
<img width="794" alt="image" src="https://github.com/jitsecurity-controls/jit-github-action/assets/12241410/6cb0a3e1-11c5-4d4f-90b6-3cdd3cacbb50">
Enrichment works on empty repo:
![image](https://github.com/jitsecurity-controls/jit-github-action/assets/12241410/657a69c7-5298-4d6c-a9c9-e5037206d58d)