### PR TITLE
Force original repo checkout to fail on non enrichment controls

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,6 @@ runs:
       shell: bash
       continue-on-error: true
       run: |
-        DUDE=${{ fromJSON(github.event.inputs.client_payload).context.job.job_name }}
         echo "Linking job ID to Jit"
         CI_RUN_ID=${{ fromJSON(github.run_id) }}
         CI_JIT_EVENT_ID=${{ fromJSON(github.event.inputs.client_payload).context.jit_event.jit_event_id }}
@@ -81,7 +80,7 @@ runs:
     - name: Ensure checkout failure is not fatal
       # if checkout fails on non enrichment job, we can't continue
       shell: bash
-      if: steps.checkout-original-repo.outcome == 'failure'
+      if: steps.checkout-original-repo.outcome == 'failure' && fromJSON(github.event.inputs.client_payload).context.job.job_name == 'enrich'
       run: |
         echo "shtoot"
         exit 1

--- a/action.yml
+++ b/action.yml
@@ -31,8 +31,8 @@ runs:
       shell: bash
       continue-on-error: true
       run: |
-        DUDE=${{ env.job }}
-        DUDE2=${{ env }}
+        DUDE=${{ fromJSON(github.event.inputs.client_payload).context.job.job_name }}
+        DUDE2=${{ fromJSON(env) }}
         echo "Linking job ID to Jit"
         CI_RUN_ID=${{ fromJSON(github.run_id) }}
         CI_JIT_EVENT_ID=${{ fromJSON(github.event.inputs.client_payload).context.jit_event.jit_event_id }}

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,7 @@ runs:
     - name: Checkout original repository
       # we don't want enrichment to fail the action on empty repo, it has its own logic to handle it
       continue-on-error: true
+      id: checkout-original-repo
       # this if should pass if there is not runner setup (old flow would checkout always) or when new flow ask to checkout
       if: ${{ ((!(fromJSON(inputs.runner_setup)) || (fromJSON(inputs.runner_setup).checkout == true)))  }}
       uses: actions/checkout@v3
@@ -75,6 +76,14 @@ runs:
         fetch-depth: 0
         token: ${{ fromJSON(github.event.inputs.client_payload).payload.github_token }}
         path: "code/"
+
+    - name: Ensure checkout failure is not fatal
+      # if checkout fails on non enrichment job, we can't continue
+      shell: bash
+      if: failure() &&  steps.checkout-original-repo.outcome == 'failure' && env.job == 'enrich'
+      run: |
+        echo "shtoot"
+        exit 1
 
     - name: Check out jit-github-actions
       uses: actions/checkout@v3

--- a/action.yml
+++ b/action.yml
@@ -77,12 +77,11 @@ runs:
         token: ${{ fromJSON(github.event.inputs.client_payload).payload.github_token }}
         path: "code/"
 
-    - name: Ensure checkout failure is not fatal
-      # if checkout fails on non enrichment job, we can't continue
+    - name: Exit if checkout failure is fatal
       shell: bash
-      if: steps.checkout-original-repo.outcome == 'failure' && fromJSON(github.event.inputs.client_payload).context.job.job_name == 'enrich'
+      if: steps.checkout-original-repo.outcome == 'failure' && fromJSON(github.event.inputs.client_payload).context.job.job_name != 'enrich'
       run: |
-        echo "shtoot"
+        echo "Original repo checkout failed, can't continue job execution"
         exit 1
 
     - name: Check out jit-github-actions

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,6 @@ runs:
       continue-on-error: true
       run: |
         DUDE=${{ fromJSON(github.event.inputs.client_payload).context.job }}
-        DUDE2=${{ fromJSON(env) }}
         echo "Linking job ID to Jit"
         CI_RUN_ID=${{ fromJSON(github.run_id) }}
         CI_JIT_EVENT_ID=${{ fromJSON(github.event.inputs.client_payload).context.jit_event.jit_event_id }}

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ runs:
       shell: bash
       continue-on-error: true
       run: |
-        DUDE=${{ fromJSON(github.event.inputs.client_payload).context.job }}
+        DUDE=${{ fromJSON(github.event.inputs.client_payload).context.job.job_name }}
         echo "Linking job ID to Jit"
         CI_RUN_ID=${{ fromJSON(github.run_id) }}
         CI_JIT_EVENT_ID=${{ fromJSON(github.event.inputs.client_payload).context.jit_event.jit_event_id }}

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,8 @@ runs:
       shell: bash
       continue-on-error: true
       run: |
+        DUDE=${{ env.job }}
+        DUDE2=${{ env }}
         echo "Linking job ID to Jit"
         CI_RUN_ID=${{ fromJSON(github.run_id) }}
         CI_JIT_EVENT_ID=${{ fromJSON(github.event.inputs.client_payload).context.jit_event.jit_event_id }}
@@ -80,7 +82,7 @@ runs:
     - name: Ensure checkout failure is not fatal
       # if checkout fails on non enrichment job, we can't continue
       shell: bash
-      if: failure() &&  steps.checkout-original-repo.outcome == 'failure' && env.job == 'enrich'
+      if: failure() &&  steps.checkout-original-repo.outcome == 'failure'
       run: |
         echo "shtoot"
         exit 1

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ runs:
       shell: bash
       continue-on-error: true
       run: |
-        DUDE=${{ fromJSON(github.event.inputs.client_payload).context.job.job_name }}
+        DUDE=${{ fromJSON(github.event.inputs.client_payload).context.job }}
         DUDE2=${{ fromJSON(env) }}
         echo "Linking job ID to Jit"
         CI_RUN_ID=${{ fromJSON(github.run_id) }}
@@ -82,7 +82,7 @@ runs:
     - name: Ensure checkout failure is not fatal
       # if checkout fails on non enrichment job, we can't continue
       shell: bash
-      if: failure() &&  steps.checkout-original-repo.outcome == 'failure'
+      if: steps.checkout-original-repo.outcome == 'failure'
       run: |
         echo "shtoot"
         exit 1


### PR DESCRIPTION
Passes with the new role:
<img width="1512" alt="image" src="https://github.com/jitsecurity-controls/jit-github-action/assets/12241410/2749797f-88aa-4af9-a4ba-92b6fa02861b">
Tested for failure scenario as well:
<img width="723" alt="image" src="https://github.com/jitsecurity-controls/jit-github-action/assets/12241410/d5716fc6-5778-4ffd-858c-b89ed06b82fb">
