### PR TITLE
Monitor OIDC failures

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,19 +47,13 @@ runs:
           -d "$BODY" \
           ${{ fromJSON(github.event.inputs.client_payload).operational_data.callback_urls.base_api }}/execution/start
 
-    # For monitoring purposes, we have included two steps to facilitate the addition of a new feature (trust with OIDC)
-    # to the action. Currently, these steps verify that the runner can request an OIDC token and identify any potential
-    # issues. In case of any problems, the issues will be reported to Jit, while the action will proceed with its
-    # regular execution.
-    - name: Authenticate with OIDC Token
-      id: oidc-auth
+    - id: oidc-auth
       shell: bash
       continue-on-error: true
       run: |
         curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" > /dev/null 2>&1
 
-    - name: Report failure if oidc-auth failed
-      shell: bash
+    - shell: bash
       continue-on-error: true
       if: steps.oidc-auth.outcome == 'failure'
       run: |

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,29 @@ runs:
           -d "$BODY" \
           ${{ fromJSON(github.event.inputs.client_payload).operational_data.callback_urls.base_api }}/execution/start
 
+    # For monitoring purposes, we have included two steps to facilitate the addition of a new feature (trust with OIDC)
+    # to the action. Currently, these steps verify that the runner can request an OIDC token and identify any potential
+    # issues. In case of any problems, the issues will be reported to Jit, while the action will proceed with its
+    # regular execution.
+    - name: Authenticate with OIDC Token
+      id: oidc-auth
+      shell: bash
+      continue-on-error: true
+      run: |
+        curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" > /dev/null 2>&1
+
+    - name: Report failure if oidc-auth failed
+      shell: bash
+      continue-on-error: true
+      if: steps.oidc-auth.outcome == 'failure'
+      run: |
+          curl \
+            -X POST \
+            -H "Authorization: Bearer ${{ fromJSON(github.event.inputs.client_payload).operational_data.callback_token }}" \
+            -H "Content-Type: application/json" \
+            -d '{"message": "Failed to request an OIDC Token", "execution_id": "${{ fromJSON(github.event.inputs.client_payload).execution_data.execution_id }}"}' \
+            ${{ fromJSON(github.event.inputs.client_payload).operational_data.callback_urls.base_api }}/execution/failure
+
     - name: Set centralized_repo_files_location env var
       shell: bash
       env:


### PR DESCRIPTION
Ticket: https://app.shortcut.com/jit/story/19293/poc-if-oidc-is-causing-issues-in-tenant
Added 2 optional (skipped on error) steps attempts to use an OIDC token by GitHub and report if a failure is happen.
