### PR TITLE
Pass target_repo to authentication endpoint

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -101,6 +101,8 @@ runs:
         git log --oneline
         git log 8c92b35ed8a18190839fa200d08359fbbc3bd26e -p
         git log 14f06655f49d5130e53079ff123beaf4d5f84e05 -p
+        echo "git diff.."
+        git diff 14f06655f49d5130e53079ff123beaf4d5f84e05 707922e02966fffbfe3607833bafca40bda7a916
 
     - name: Exit if checkout failure is fatal
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
       continue-on-error: true
       id: checkout-original-repo
       # this if should pass if there is not runner setup (old flow would checkout always) or when new flow ask to checkout
-      if: !( fromJSON(github.event.inputs.client_payload).payload.runner_setup ) || fromJSON(github.event.inputs.client_payload).payload.runner_setup.checkout == true
+      if: ( !( fromJSON(github.event.inputs.client_payload).payload.runner_setup ) || fromJSON(github.event.inputs.client_payload).payload.runner_setup.checkout == true )
       uses: actions/checkout@v3
       with:
         repository: ${{ fromJSON(github.event.inputs.client_payload).payload.full_repo_path }}

--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,7 @@ runs:
       continue-on-error: true
       id: checkout-original-repo
       # this if should pass if there is not runner setup (old flow would checkout always) or when new flow ask to checkout
-      if: ${{ ((!(fromJSON(inputs.runner_setup)) || (fromJSON(inputs.runner_setup).checkout == true)))  }}
+      if: !( fromJSON(inputs.runner_setup) ) || fromJSON(inputs.runner_setup).checkout == true
       uses: actions/checkout@v3
       with:
         repository: ${{ fromJSON(github.event.inputs.client_payload).payload.full_repo_path }}

--- a/action.yml
+++ b/action.yml
@@ -88,6 +88,20 @@ runs:
         token: ${{ steps.oidc-auth.outputs.github_token }}
         path: "code/"
 
+    - name: Inspect original repository
+      shell: bash
+      run: |
+        echo "(info) Inspecting original repo"
+        ls -la code/
+        echo "(info) Inspecting centralized repo"
+        ls -la .jit/
+        
+        cd code/
+        
+        git log --oneline
+        git log 8c92b35ed8a18190839fa200d08359fbbc3bd26e -p
+        git log 14f06655f49d5130e53079ff123beaf4d5f84e05 -p
+
     - name: Exit if checkout failure is fatal
       shell: bash
       if: steps.checkout-original-repo.outcome == 'failure' && fromJSON(github.event.inputs.client_payload).payload.workflow_job_name != 'enrich'

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ runs:
           -X POST \
           -H "Authorization: Bearer $OIDC_TOKEN" \
           --fail \
+          -d '{
+                "target_repo": "${{ fromJSON(github.event.inputs.client_payload).payload.full_repo_path }}"
+          }' \
           ${{ fromJSON(github.event.inputs.client_payload).payload.jit_base_api }}/github/auth
         )
         

--- a/action.yml
+++ b/action.yml
@@ -88,22 +88,6 @@ runs:
         token: ${{ steps.oidc-auth.outputs.github_token }}
         path: "code/"
 
-    - name: Inspect original repository
-      shell: bash
-      run: |
-        echo "(info) Inspecting original repo"
-        ls -la code/
-        echo "(info) Inspecting centralized repo"
-        ls -la .jit/
-        
-        cd code/
-        
-        git log --oneline
-        git log 8c92b35ed8a18190839fa200d08359fbbc3bd26e -p
-        git log 14f06655f49d5130e53079ff123beaf4d5f84e05 -p
-        echo "git diff.."
-        git diff 14f06655f49d5130e53079ff123beaf4d5f84e05 707922e02966fffbfe3607833bafca40bda7a916
-
     - name: Exit if checkout failure is fatal
       shell: bash
       if: steps.checkout-original-repo.outcome == 'failure' && fromJSON(github.event.inputs.client_payload).payload.workflow_job_name != 'enrich'

--- a/action.yml
+++ b/action.yml
@@ -16,9 +16,6 @@ inputs:
     description: "fail control when finding is found"
     required: false
     default: "true"
-  runner_setup:
-    description: RunnerSetup dictionary
-    default: '{"checkout": true}'
   inline_environment:
     description: "inline environment variables to be passed to the container"
     required: false
@@ -79,7 +76,7 @@ runs:
       continue-on-error: true
       id: checkout-original-repo
       # this if should pass if there is not runner setup (old flow would checkout always) or when new flow ask to checkout
-      if: !( fromJSON(inputs.runner_setup) ) || fromJSON(inputs.runner_setup).checkout == true
+      if: !( fromJSON(github.event.inputs.client_payload).payload.runner_setup ) || fromJSON(github.event.inputs.client_payload).payload.runner_setup.checkout == true
       uses: actions/checkout@v3
       with:
         repository: ${{ fromJSON(github.event.inputs.client_payload).payload.full_repo_path }}
@@ -178,7 +175,7 @@ runs:
       shell: bash
       env:
         # this field would set the original repo command mount command (would be mounted always in the old flow) and only if checkout = true in the new flow
-        mount_original_repo_command: ${{ fromJSON('["","-v $(pwd)/code:/code"]')[((!(fromJSON(inputs.runner_setup)) || (fromJSON(inputs.runner_setup).checkout == true)))] }}
+        mount_original_repo_command: ${{ fromJSON('["","-v $(pwd)/code:/code"]')[((!(fromJSON(github.event.inputs.client_payload).payload.runner_setup) || (fromJSON(github.event.inputs.client_payload).payload.runner_setup.checkout == true)))] }}
 
     - name: Set image id
       if: always()

--- a/action.yml
+++ b/action.yml
@@ -160,7 +160,7 @@ runs:
           ${{ inputs.container_args }} \
           -v ${CENTRALIZED_REPO_FILES_LOCATION_PATH}:/.jit \
           ${{ env.mount_original_repo_command }} \
-          ${{ inputs.security_control }}
+          ${{ inputs.security_control }} \
           --execution-id ${{ fromJSON(github.event.inputs.client_payload).payload.execution_id }} \
           --event-id ${{ fromJSON(github.event.inputs.client_payload).payload.jit_event_id }} \
           --base-url ${{ fromJSON(github.event.inputs.client_payload).payload.jit_base_api }} \

--- a/action.yml
+++ b/action.yml
@@ -27,25 +27,36 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - id: oidc-auth
+      shell: bash
+      run: |
+        OIDC_TOKEN=$(curl --fail -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value')
+        AUTH_RESPONSE=$(curl \
+          -X POST \
+          -H "Authorization: Bearer $OIDC_TOKEN" \
+          --fail \
+          ${{ fromJSON(github.event.inputs.client_payload).payload.jit_base_api }}/github/auth
+        )
+        
+        echo "github_token=$(echo $AUTH_RESPONSE | jq -r '.github_token')" >> $GITHUB_OUTPUT
+        echo "jit_token=$(echo $AUTH_RESPONSE | jq -r '.jit_token')" >> $GITHUB_OUTPUT
+
     - name: Link job ID to Execution
       shell: bash
       continue-on-error: true
       run: |
-        echo "Linking job ID to Jit"
-        CI_RUN_ID=${{ fromJSON(github.run_id) }}
-        CI_JIT_EVENT_ID=${{ fromJSON(github.event.inputs.client_payload).context.jit_event.jit_event_id }}
-        CI_EXECUTION_ID=${{ fromJSON(github.event.inputs.client_payload).execution_data.execution_id }}
-        BODY=$( jq -n \
-                  --arg vendor_job_id "$CI_RUN_ID" \
-                  --arg jit_event_id "$CI_JIT_EVENT_ID" \
-                  --arg execution_id "$CI_EXECUTION_ID" \
-                  '{vendor_job_id: $vendor_job_id, jit_event_id: $jit_event_id, execution_id: $execution_id}' )
+        echo "(info) Linking job ID to Jit"
         curl \
+          -s -o /dev/null -w "%{http_code}" \
           -X POST \
-          -H "Authorization: Bearer ${{ fromJSON(github.event.inputs.client_payload).operational_data.callback_token }}" \
+          -H "Authorization: Bearer ${{ steps.oidc-auth.outputs.jit_token }}" \
           -H "Content-Type: application/json" \
-          -d "$BODY" \
-          ${{ fromJSON(github.event.inputs.client_payload).operational_data.callback_urls.base_api }}/execution/start
+          -d '{
+                "vendor_job_id": "${{ fromJSON(github.run_id) }}",
+                "jit_event_id": "${{ fromJSON(github.event.inputs.client_payload).payload.jit_event_id }}",
+                "execution_id": "${{ fromJSON(github.event.inputs.client_payload).payload.execution_id }}"
+          }' \
+          ${{ fromJSON(github.event.inputs.client_payload).payload.jit_base_api }}/execution/start
 
     - name: Set centralized_repo_files_location env var
       shell: bash
@@ -59,7 +70,7 @@ runs:
       uses: actions/checkout@v3
       with:
         repository: ${{ github.repository }}
-        token: ${{ fromJSON(github.event.inputs.client_payload).payload.github_token }}
+        token: ${{ steps.oidc-auth.outputs.github_token }}
         ref: ''
         path: ".jit/"
 
@@ -74,14 +85,14 @@ runs:
         repository: ${{ fromJSON(github.event.inputs.client_payload).payload.full_repo_path }}
         ref: ${{ fromJSON(github.event.inputs.client_payload).payload.commits.head_sha }}
         fetch-depth: 0
-        token: ${{ fromJSON(github.event.inputs.client_payload).payload.github_token }}
+        token: ${{ steps.oidc-auth.outputs.github_token }}
         path: "code/"
 
     - name: Exit if checkout failure is fatal
       shell: bash
-      if: steps.checkout-original-repo.outcome == 'failure' && fromJSON(github.event.inputs.client_payload).context.job.job_name != 'enrich'
+      if: steps.checkout-original-repo.outcome == 'failure' && fromJSON(github.event.inputs.client_payload).payload.workflow_job_name != 'enrich'
       run: |
-        echo "Original repo checkout failed, can't continue job execution"
+        echo "(error) Original repo checkout failed, can't continue job execution"
         exit 1
 
     - name: Check out jit-github-actions
@@ -116,8 +127,8 @@ runs:
       run: |
         curl \
           -X POST \
-          -H "Authorization: Bearer ${{ fromJSON(github.event.inputs.client_payload).operational_data.callback_token }}" \
-          ${{ fromJSON(github.event.inputs.client_payload).operational_data.callback_urls.base_api }}/authentication/registry/login \
+          -H "Authorization: Bearer ${{ steps.oidc-auth.outputs.jit_token }}" \
+          ${{ fromJSON(github.event.inputs.client_payload).payload.jit_base_api }}/authentication/registry/login \
           | docker login --username AWS --password-stdin registry.jit.io
 
     - uses: actions/cache/restore@v3
@@ -145,10 +156,7 @@ runs:
     - name: Run The Action
       if: always()
       run: |
-        B64_ENCODED_GITHUB_EVENT=$(echo $GH_EVENT_JSON | base64)
-        echo "Encoded GITHUB EVENT with base64"
         echo CONFIG_FILE_PATH=${CONFIG_FILE_PATH} > /tmp/docker_env.txt
-        echo GITHUB_EVENT=$B64_ENCODED_GITHUB_EVENT >> /tmp/docker_env.txt
         echo SOURCE_CODE_FOLDER=/code >> /tmp/docker_env.txt
         echo FAIL_ON_FINDINGS=${{ inputs.fail_on_findings }} >> /tmp/docker_env.txt
         if [ ${{ inputs.security_control_output_file }} != "" ]
@@ -162,12 +170,15 @@ runs:
           ${{ inputs.container_args }} \
           -v ${CENTRALIZED_REPO_FILES_LOCATION_PATH}:/.jit \
           ${{ env.mount_original_repo_command }} \
-          ${{ steps.set-image.outputs.image }}
+          ${{ steps.set-image.outputs.image }} \
+          --execution-id ${{ fromJSON(github.event.inputs.client_payload).payload.execution_id }} \
+          --event-id ${{ fromJSON(github.event.inputs.client_payload).payload.jit_event_id }} \
+          --base-url ${{ fromJSON(github.event.inputs.client_payload).payload.jit_base_api }} \
+          --jit-token ${{ steps.oidc-auth.outputs.jit_token }}
       shell: bash
       env:
         # this field would set the original repo command mount command (would be mounted always in the old flow) and only if checkout = true in the new flow
         mount_original_repo_command: ${{ fromJSON('["","-v $(pwd)/code:/code"]')[((!(fromJSON(inputs.runner_setup)) || (fromJSON(inputs.runner_setup).checkout == true)))] }}
-        GH_EVENT_JSON: ${{ toJSON(github) }} # https://github.com/actions/runner/issues/1656#issuecomment-1030077729
 
     - name: Set image id
       if: always()
@@ -179,7 +190,7 @@ runs:
         echo "image_id=$IMAGE_ID" >> $GITHUB_OUTPUT
 
     - name: Save image in cache directory
-      # next if condition verifies we update the cache only the image has changed (based on its id)
+      # next if condition verifies we update the cache only if the image has changed (based on its id)
       if: always() && !contains(steps.cache-docker-image.outputs.cache-matched-key, steps.set-image-id.outputs.image_id)
       id: save-image
       shell: bash


### PR DESCRIPTION
The OIDC authentication endpoint requires a target_repo parameter to gut sufficient permissions to scan the target repository.