### PR TITLE
sending also execution id and jit_event id to the GH auth in jit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,9 @@ runs:
           -H "Authorization: Bearer $OIDC_TOKEN" \
           --fail \
           -d '{
-                "target_repo": "${{ fromJSON(github.event.inputs.client_payload).payload.full_repo_path }}"
+                "target_repo": "${{ fromJSON(github.event.inputs.client_payload).payload.full_repo_path }}",
+                "jit_event_id": "${{ fromJSON(github.event.inputs.client_payload).payload.jit_event_id }}",
+                "execution_id": "${{ fromJSON(github.event.inputs.client_payload).payload.execution_id }}"
           }' \
           ${{ fromJSON(github.event.inputs.client_payload).payload.jit_base_api }}/github/auth
         )


### PR DESCRIPTION
https://app.shortcut.com/jit/story/19671/oidc-add-additional-security-layer