### PR TITLE
upgrade docker cache action to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -212,7 +212,7 @@ runs:
           exit 103
         fi
 
-    - uses: actions/cache/restore@v3
+    - uses: actions/cache/restore@v4
       if: steps.set-cache-file.outputs.cache_file != ''
       id: cache-docker-image
       continue-on-error: true
@@ -258,7 +258,7 @@ runs:
         fi
         docker save ${{ inputs.security_control }} -o ci/cache/docker/${{ steps.set-cache-file.outputs.cache_file }}@${{ steps.set-image-id.outputs.image_id }}.tar
 
-    - uses: actions/cache/save@v3
+    - uses: actions/cache/save@v4
       continue-on-error: true
       if: steps.save-image.conclusion == 'success'
       with:


### PR DESCRIPTION
When making changes to a control, the image has to be re-downloaded from ECR before caching it for further uses
We've been experiencing slow-downs in the completion of the operation due to Node.Js 20 not properly terminating the process on completion

Upgrading to v4 fixes this issue

Before

![image](https://github.com/user-attachments/assets/58ad1118-9178-4e23-8bff-35d4c9c57d7d)

After

![image](https://github.com/user-attachments/assets/7bc24668-4b86-4ca3-9ef2-48afe04c925b)
